### PR TITLE
README.md - updated path to localhost site to match the path being served

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ The profiles are used for record-keeping and contact information.
     bundle exec jekyll serve --watch
     ```
 
-1. Browse to http://localhost:4000
+1. Browse to http://localhost:4000/people/
 
 Ta-da, the project should appear locally in your browser.
 


### PR DESCRIPTION
The site is seems to be served at http://localhost:4000/people/. The "/people/" part of the path is not mentioned in the README.md